### PR TITLE
[no jira] Add usage docs and examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,31 @@
 
 A fundamental sentence splitter based on [spacy](https://spacy.io/).
 
+## Usage
+
+```python
+from fun_sentence_splitter import init
+
+splitter = init(spacy_model="de_core_news_sm")
+
+for sentence in splitter("Das ist ein Satz. Und hier noch einer!"):
+    print(sentence.text, sentence.span)
+```
+
+`init(...)` returns a splitter function. Each `Sentence` exposes `.text` and `.span` (a `(start, end)` index pair into the original text).
+
+Split on line breaks first (e.g. for structured documents) and only run spaCy on longer lines:
+
+```python
+splitter = init(
+    spacy_model="de_core_news_sm",
+    always_split_on_line_breaks=True,
+    max_len_before_split=100,
+)
+```
+
+> Download the language model once: `uv run python -m spacy download de_core_news_sm`
+
 ## Requirements
 
 [uv](https://docs.astral.sh/uv/).


### PR DESCRIPTION
Adds a **Usage** section with code examples to the README (basic split + line-based mode), addressing #28. Doc-only change, no version bump (conditional publish skips).

Example verified locally against the current API (`init` -> splitter -> `Sentence.text` / `Sentence.span`).

Closes #28.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a README Usage section with examples for basic sentence splitting and line-based mode.
- Documented `init`, sentence `.text` and `.span`, configuration options, and spaCy model setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->