### PR TITLE
[no jira] Switch PyPI publish to Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # OIDC trusted publishing (no long-lived token)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up uv
@@ -30,6 +32,4 @@ jobs:
         if: steps.version.outputs.published == 'false'
         run: |
           uv build
-          uv publish
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          uv publish --trusted-publishing always

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fun-sentence-splitter"
-version = "0.6.3814.20260724"
+version = "0.7.3814.20260724"
 description = "A fundamental sentence splitter based on spacy."
 authors = [{ name = "Medical AI Engineering", email = "engineering@m-ai.com" }]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -248,7 +248,7 @@ wheels = [
 
 [[package]]
 name = "fun-sentence-splitter"
-version = "0.6.3814.20260724"
+version = "0.7.3814.20260724"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Switches `publish.yml` from the long-lived `PYPI_TOKEN` to **PyPI Trusted Publishing (OIDC)**:

- publish job gets `permissions: id-token: write`
- `uv publish --trusted-publishing always` (no token)
- removes the `UV_PUBLISH_TOKEN` env

Prerequisite: the trusted publisher must be configured on PyPI (owner=mia-gmbh, repo=fun-sentence-splitter, workflow=publish.yml) — done.

After this is merged and a release confirms OIDC works, the `PYPI_TOKEN` secret (GitHub) and the PyPI API token can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Migrates PyPI publishing from long-lived tokens to OIDC Trusted Publishing.
- Grants `id-token: write` to the publish job and uses `uv publish --trusted-publishing always`.
- Removes the `UV_PUBLISH_TOKEN` environment variable (no long-lived token usage in the publish step).
- Keeps the existing “Skip if version is already on PyPI” check; it only runs the trusted publishing publish when the version isn’t already present.
- After successful OIDC-based publishing is confirmed, the obsolete GitHub and PyPI tokens can be deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->